### PR TITLE
Fix "Use `is` or `is not` to compare with `None`" issue

### DIFF
--- a/scripts/add_text.py
+++ b/scripts/add_text.py
@@ -27,7 +27,7 @@ def main():
     
     writer = None
     for row in csv.DictReader(sys.stdin, delimiter="\t"):
-        if writer == None:
+        if writer is None:
             writer = csv.DictWriter(sys.stdout, list(row.keys()) + ['text'],
                                     delimiter="\t")
             writer.writeheader()


### PR DESCRIPTION
This pull request automatically fixes all occurrences of the following issue:

Issue type: [Use `is` or `is not` to compare with `None`](https://www.quantifiedcode.com/app/issue_class/3IY8CZ0v)
Issue details: [https://www.quantifiedcode.com/app/project/gh:runt18:Wiki-Class?groups=code_patterns/%3A3IY8CZ0v](https://www.quantifiedcode.com/app/project/gh:runt18:Wiki-Class?groups=code_patterns/%3A3IY8CZ0v)

To adjust the commit message or the actual code changes, just [rebase](https://git-scm.com/docs/git-rebase) or [cherry-pick](https://git-scm.com/docs/git-cherry-pick) the commits.
For questions or feedback reach out to cody@quantifiedcode.com.

Legal note: We won't claim any copyrights on the code changes.

Cheers,
[Cody - Your code quality bot](https://www.quantifiedcode.com/cody)
